### PR TITLE
New format specifiers: {semester-lexical} and {semester-lexical-short}

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,21 +126,23 @@ ASCII. The following attributes are available:
     following placeholders are available:
 
     ```
-    {semester}        Course semester (e.g. "WS 16/17")
-    {course-id}       Course hash-id
-    {course}          Course name
-    {course-abbrev}   Auto-generated course name abbreviation (e.g. "LinAlgI")
-    {type}            Course type (e.g. "Lecture")
-    {type-abbrev}     Abbreviation of the course type (e.g. "L")
-    {path}            Path of the file's containing directory
-    {short-path}      Like {path}, but with "Allgemeiner Dateiordner" removed
-    {id}              File hash-id
-    {name}            Original file name, without extension
-    {ext}             File extension (e.g. "pdf")
-    {description}     Full file description
-    {descr-no-ext}    Like {description}, but with the file extension stripped (if any)
-    {author}          File author's name
-    {time}            Time of creation (e.g. "2017-03-02 13:12")
+    {semester}                  Course semester (e.g. "WS 16/17")
+    {semester-lexical}          Course semester in lexically sortable format (e.g. "2016WS17")
+    {semester-lexical-short}    Course semester in lexically sortable format (e.g. "2016WS")
+    {course-id}                 Course hash-id
+    {course}                    Course name
+    {course-abbrev}             Auto-generated course name abbreviation (e.g. "LinAlgI")
+    {type}                      Course type (e.g. "Lecture")
+    {type-abbrev}               Abbreviation of the course type (e.g. "L")
+    {path}                      Path of the file's containing directory
+    {short-path}                Like {path}, but with "Allgemeiner Dateiordner" removed
+    {id}                        File hash-id
+    {name}                      Original file name, without extension
+    {ext}                       File extension (e.g. "pdf")
+    {description}               Full file description
+    {descr-no-ext}              Like {description}, but with the file extension stripped (if any)
+    {author}                    File author's name
+    {time}                      Time of creation (e.g. "2017-03-02 13:12")
     ```
 
 - `base`: The base directory containing the view's directory tree. If there is only one view,

--- a/studip/views.py
+++ b/studip/views.py
@@ -21,6 +21,13 @@ def abbreviate_course(name):
         abbrev = "".join(w[0] for w in words if len(w) > 0)
     return abbrev + number
 
+def lexicalise_semester(semester, short=False):
+    """Takes input of the form "SS 16" or "WS 16/17" and converts it to "2016SS" or "2016WS17"."""
+    if short:
+        return re.sub(r'^(SS|WS) (\d{2})(.(\d{2}))?', r'20\2\1', semester)
+    else:
+        return re.sub(r'^(SS|WS) (\d{2})(.(\d{2}))?', r'20\2\1\4', semester)
+
 def abbreviate_type(type):
     special_abbrevs = {
         "Arbeitsgemeinschaft": "AG",
@@ -124,6 +131,8 @@ class ViewSynchronizer:
 
                 tokens = {
                     "semester": fs_escape(file.course_semester),
+                    "semester-lexical": fs_escape(lexicalise_semester(file.course_semester)),
+                    "semester-lexical-short": fs_escape(lexicalise_semester(file.course_semester, short=True)),
                     "course-id": file.course,
                     "course-abbrev": fs_escape(abbreviate_course(file.course_name)),
                     "course": fs_escape(file.course_name),
@@ -209,6 +218,8 @@ class ViewSynchronizer:
             # Construct a dummy file for extracting the fromatted path
             tokens = {
                 "semester": fs_escape(course.semester),
+                "semester-lexical": fs_escape(lexicalise_semester(course.semester)),
+                "semester-lexical-short": fs_escape(lexicalise_semester(course.semester, short=True)),
                 "course-id": course.id,
                 "course": fs_escape(course.name),
                 "course-abbrev": fs_escape(abbreviate_course(course.name)),

--- a/studip/views.py
+++ b/studip/views.py
@@ -6,6 +6,7 @@ from .util import ellipsize, escape_file_name
 
 WORD_SEPARATOR_RE = re.compile(r'[-. _/()]+')
 NUMBER_RE = re.compile(r'^([0-9]+)|([IVXLCDM]+)$')
+SEMESTER_RE = re.compile(r'^(SS|WS) (\d{2})(.(\d{2}))?')
 
 
 def abbreviate_course(name):
@@ -24,9 +25,9 @@ def abbreviate_course(name):
 def lexicalise_semester(semester, short=False):
     """Takes input of the form "SS 16" or "WS 16/17" and converts it to "2016SS" or "2016WS17"."""
     if short:
-        return re.sub(r'^(SS|WS) (\d{2})(.(\d{2}))?', r'20\2\1', semester)
+        return SEMESTER_RE.sub(r'20\2\1', semester)
     else:
-        return re.sub(r'^(SS|WS) (\d{2})(.(\d{2}))?', r'20\2\1\4', semester)
+        return SEMESTER_RE.sub(r'20\2\1\4', semester)
 
 def abbreviate_type(type):
     special_abbrevs = {


### PR DESCRIPTION
The default semester format of "SS 16", "WS 16/17", etc results in incorrect order when sorting lexically:
    SS 15, SS 16, SS 17, WS 15/16, WS 16/17, WS 17/18
Add a format specifier that transforms this into a format that can be sorted properly:
    2015SS, 2015WS16, 2016SS, 2016WS17, 2017SS, 2017WS18

Alternatively, there's {semester-lexical-short}, which omits the second year number for winter semesters (2016WS17 becomes 2016WS).